### PR TITLE
Fix dev server port conflict

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "tasks": {
+  "pipeline": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- update Turborepo config schema
- run Next.js dev server explicitly on port 3000

## Testing
- `npm run dev` (Next.js on port 3000, API on port 3001)
- `curl -I http://localhost:3000`
- `curl -I http://localhost:3001/api/health`


------
https://chatgpt.com/codex/tasks/task_e_68402277411483298baf597838b909dc